### PR TITLE
Week8 基本題+ Hw1、2 進階挑戰題

### DIFF
--- a/homeworks/week8/hw1/index.html
+++ b/homeworks/week8/hw1/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+
+<html>
+  <head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1'> 
+    <title>Week8-hw1 Lottery（Cindy）</title>
+    <link rel='stylesheet' href='./style.css'>
+  </head>
+  <body>
+    <div class='start pickout'>抽獎 GO!</div>
+    <div class='prize'></div>
+    <script src='./index.js'></script>
+  </body>
+</html>

--- a/homeworks/week8/hw1/index.js
+++ b/homeworks/week8/hw1/index.js
@@ -1,0 +1,97 @@
+const request = new XMLHttpRequest();
+const html = document.querySelector('html');
+const body = document.querySelector('body');
+const prizeElement = document.createElement('div');
+prizeElement.classList.add('prize__content');
+const prize = document.querySelector('.prize');
+const pickout = document.querySelector('.pickout');
+const start = document.querySelector('.start');
+let bgColor;
+
+function playAgain() {
+  start.classList.add('pickout');
+  start.innerText = '抽獎 GO!';
+  body.classList.remove(bgColor);
+  prize.innerHTML = ' ';
+  startPlay();
+}
+
+function content(url, title, info, credit) {
+  prizeElement.innerHTML = `<img class='prize__image' src='${url}'>
+            <div class='prize__info title'>${title}</div>
+            <div class='prize__info'>${info}</div>
+            <div class='prize__point'>點擊任一處返回</div>
+            <div class='prize__credit'>${credit}</div>`;
+}
+
+function startPlay() {
+  pickout.addEventListener('click',
+    () => {
+      request.onload = () => {
+        if (request.status >= 200 && request.status <= 400) {
+          const data = JSON.parse(request.responseText);
+          let url;
+          let title;
+          let info;
+          let credit;
+          start.innerText = '';
+          start.classList.remove('pickout');
+          switch (data.prize) {
+            case 'FIRST':
+              bgColor = 'color__skyblue';
+              body.classList.add(bgColor);
+              url = 'ttps://image.flaticon.com/icons/svg/201/201623.svg';
+              title = '頭獎';
+              info = '恭喜你中頭獎了！日本東京來回雙人遊！';
+              credit = 'Icon made by Icon Pond from www.flaticon.com';
+              content(url, title, info, credit);
+              prize.appendChild(prizeElement);
+              html.addEventListener('click', playAgain);
+              break;
+            case 'SECOND':
+              bgColor = 'color__grey';
+              body.classList.add(bgColor);
+              url = 'https://image.flaticon.com/icons/svg/326/326023.svg';
+              title = '二獎';
+              info = '二獎！90 吋電視一台！';
+              credit = 'Icon made by Icon Pond from www.flaticon.com';
+              content(url, title, info, credit);
+              prize.appendChild(prizeElement);
+              html.addEventListener('click', playAgain);
+              break;
+            case 'THIRD':
+              bgColor = 'color__orange';
+              body.classList.add(bgColor);
+              url = 'https://image.flaticon.com/icons/svg/946/946748.svg';
+              title = '三獎';
+              info = '恭喜你抽中三獎：知名 YouTuber 簽名握手會入場券一張，bang！';
+              credit = 'Icon made by Icon Pond from www.flaticon.com';
+              content(url, title, info, credit);
+              prize.appendChild(prizeElement);
+              html.addEventListener('click', playAgain);
+              break;
+            default: // 當'NONE'時
+              bgColor = 'color__black';
+              body.classList.add(bgColor);
+              url = 'https://image.flaticon.com/icons/svg/1201/1201958.svg';
+              title = '銘謝惠顧';
+              info = '';
+              credit = 'Icon made by Freepik from www.flaticon.com';
+              content(url, title, info, credit);
+              prize.appendChild(prizeElement);
+              html.addEventListener('click', playAgain);
+              break;
+          }
+        } else {
+          alert('系統不穩定請再試一次');
+        }
+      };
+      request.onerror = () => {
+        alert('系統不穩定請再試一次', request.status);
+      };
+      request.open('GET', 'https://dvwhnbka7d.execute-api.us-east-1.amazonaws.com/default/lottery', true);
+      request.send();
+    });
+}
+
+startPlay();

--- a/homeworks/week8/hw1/style.css
+++ b/homeworks/week8/hw1/style.css
@@ -1,0 +1,64 @@
+.pickout {
+  border-radius: 5px;
+  display: inline-block;
+  padding: 15px 40px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  background-color: #fce5c7;
+  color: #f98f04;
+  transition: 0.3s;
+}
+
+.pickout:hover {
+  background-color: #f9ddb6;
+}
+
+.color__skyblue {
+  background-color: #d6e4fc;
+  color: #6f83a5;
+}
+
+.color__grey {
+  background-color: #c4c4c4;
+  color: #5f5e5e;
+}
+
+.color__orange {
+  background-color: #ffe2b6;
+}
+
+.color__black {
+  background-color: #7c7c7c;
+  color: white;
+}
+
+.prize__info.title {
+  font-weight: bold;
+  font-size: 50px;
+}
+
+.prize {
+  text-align: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.prize__image {
+  width: 200px;
+}
+
+.prize__info {
+  font-size: 30px;
+  margin-top: 50px;
+}
+
+.prize__point, .prize__credit {
+  margin-top: 50px;
+  font-size: 14px;
+  opacity: 0.5;
+}

--- a/homeworks/week8/hw2/index.html
+++ b/homeworks/week8/hw2/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE HTML>
+
+<html>
+  <head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <title>Week8-hw2 Message Board（Cindy）</title>
+    <link rel='stylesheet' href='./style.css'>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
+  </head>
+  <body>
+    <div class='messageboard'>
+      <div class='messageboard__title'>留言板<i class='far fa-comment'></i></div>
+      <div class='messageboard__intr'>王媽媽：歡迎跟我們分享你的任何想法～</div>
+      <form class='messageboard__newpost'>
+        <textarea type='text' class='messageboard__newpost-input'></textarea><br>
+        <div class='messageboard__newpost-submit'>送出</div>
+      </form>
+      <hr class='messagebord__hr'>
+      <div class='messageboard__subtitle'>最新留言</div>
+      <div class='messageboard__latestpost-region'>
+    </div>
+    <div class='messageboard__changepage'>
+    </div>
+    <script src='./index.js'></script>
+  </body>
+</html>

--- a/homeworks/week8/hw2/index.js
+++ b/homeworks/week8/hw2/index.js
@@ -1,0 +1,106 @@
+const request = new XMLHttpRequest();
+const newpostSubmit = document.querySelector('.messageboard__newpost-submit');
+const newpostInput = document.querySelector('.messageboard__newpost-input');
+const changePage = document.querySelector('.messageboard__changepage');
+const latestPostRegion = document.querySelector('.messageboard__latestpost-region');
+let finalId;
+let page;
+let data;
+
+function countEnd(dataLength, clickPage) {
+  if ((dataLength - clickPage * 20 - 1) > 0) {
+    return dataLength - clickPage * 20 - 1;
+  }
+  return 0;
+}
+
+// 點擊換頁
+changePage.onclick = (e) => {
+  const dataLength = data.length;
+  const clickPage = parseInt(e.target.innerText, 10); // 點擊到第幾頁
+  if (clickPage <= page) { // 防止手滑點到非頁數的地方
+    const changePageChildTarget = document.querySelector(`#page-button${clickPage}`);
+    const activePageNum = document.querySelector('.active').innerText;
+    const activePage = document.querySelector(`#page-button${activePageNum}`);
+    activePage.classList.remove('active');
+    changePageChildTarget.classList.add('active');
+    let startID = dataLength - 1; // 當頁數為 1 時取的第一個 ID 值
+    let endID = dataLength - 20; // 當頁數為 1 時取的最後一個 ID 值
+    if (clickPage > 1) {
+      startID = dataLength - 21 * (clickPage - 1); // 當頁數大於 1 時取的第一個 ID 值
+      endID = countEnd(dataLength, clickPage); // 當頁數大於 1 時取的最後一個 ID 值
+    }
+    latestPostRegion.innerHTML = '';
+    for (let r = startID; r >= endID; r -= 1) {
+      const latestPost = document.createElement('div');
+      latestPost.classList.add('messageboard__latestpost');
+      const id = data[r].id;
+      const content = data[r].content;
+      latestPost.innerHTML = `<div class='messageboard__latestpost-info'><i class="fas fa-user-circle"></i><span class='messageboard__latestpost-id'></span>${id}</div>
+        <div class='messageboard__latestpost-content'>${content}</div>`;
+      latestPostRegion.appendChild(latestPost);
+    }
+    window.scroll(0, 0);
+  }
+};
+
+// 當頁面載入時
+request.onload = () => {
+  if (request.status >= 200 && request.status <= 400) {
+    data = JSON.parse(request.responseText);
+    page = Math.ceil((data.length) / 20);
+    finalId = data.length + 1;
+    for (let k = 1; k <= page; k += 1) {
+      const num = document.createElement('div');
+      num.classList.add('messageboard__changepage-child');
+      num.id = `page-button${k}`;
+      num.innerText = k;
+      if (k === 1) {
+        num.classList.add('active');
+      }
+      changePage.appendChild(num);
+    }
+    for (let i = data.length - 1; i >= data.length - 20; i -= 1) {
+      const latestPost = document.createElement('div');
+      latestPost.classList.add('messageboard__latestpost');
+      const id = data[i].id;
+      const content = data[i].content;
+      latestPost.innerHTML = `<div class='messageboard__latestpost-info'><i class="fas fa-user-circle"></i><span class='messageboard__latestpost-id'></span>${id}</div>
+          <div class='messageboard__latestpost-content'>${content}</div>`;
+      latestPostRegion.appendChild(latestPost);
+    }
+  } else {
+    console.log('error', request.status);
+  }
+};
+
+request.onerror = () => {
+  console.log('error2', request.status);
+};
+
+request.open('GET', 'https://lidemy-book-store.herokuapp.com/posts?', true);
+request.send();
+
+// 提交新留言
+newpostSubmit.onclick = () => {
+  const request2 = new XMLHttpRequest();
+  const storePostInputValue = newpostInput.value;
+  newpostInput.value = '';
+  request2.open('POST', 'https://lidemy-book-store.herokuapp.com/posts', true);
+  request2.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  request2.send(`content=${storePostInputValue}`);
+  request2.onload = () => {
+    if (request2.status >= 200 && request2.status <= 400) {
+      alert('留言成功');
+      const latestPost = document.createElement('div');
+      latestPost.classList.add('messageboard__latestpost');
+      const id = finalId;
+      const content = storePostInputValue;
+      latestPost.innerHTML = `<div class='messageboard__latestpost-info'><i class="fas fa-user-circle"></i><span class='messageboard__latestpost-id'></span>${id}</div>
+          <div class='messageboard__latestpost-content'>${content}</div>`;
+      latestPostRegion.prepend(latestPost);
+    } else {
+      alert(`留言失敗，請稍後再試（錯誤碼：${request2.status}）`);
+    }
+  };
+};

--- a/homeworks/week8/hw2/style.css
+++ b/homeworks/week8/hw2/style.css
@@ -1,0 +1,152 @@
+* {
+  color: #666666;
+  box-sizing: border-box;
+}
+
+.messageboard {
+  display: inline-block;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 1200px;
+}
+
+.messageboard__title {
+  font-size: 50px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 20px;
+  margin-top: 30px;
+}
+
+.fa-comment {
+  margin-left: 20px;
+}
+
+.messageboard__newpost {
+  display: flex;
+  flex-direction: column;
+}
+  
+.messageboard__newpost-input {
+  border: solid 1px rgb(180, 180, 180);
+  height: 120px;
+  padding: 10px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+.messageboard__newpost-input:focus {
+  border: solid 2px #d68686;
+  outline: none;
+}
+
+.messagebord__hr, .messageboard__newpost-input {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.messagebord__hr {
+  max-width: 580px;
+  opacity: 0.4;
+}
+
+.messageboard__newpost-submit {
+  display: inline-flex;
+  padding: 7px 25px;
+  border-radius: 3px;
+  border: solid 1px rgb(180, 180, 180);
+  cursor: pointer;
+  align-self: flex-end;
+}
+
+.messageboard__newpost-submit:hover {
+  border: solid 1px rgb(102, 102, 102);
+}
+
+.messageboard__subtitle {
+  opacity: 0.5;
+  font-size: 18px;
+}
+
+.messageboard__latestpost-region {
+  margin-bottom: 50px;
+}
+
+.messageboard__latestpost {
+  border: solid 1px rgba(102, 102, 102, 0.4);
+  margin-top: 20px;
+  margin-bottom: 10px;
+  padding: 10px 10px;
+  max-width: 600px;
+}
+
+.messageboard__latestpost-info {
+  opacity: 0.6;
+}
+
+.fa-user-circle {
+  font-size: 25px;
+}
+
+.messageboard__latestpost-id:before {
+  content: '匿名 ';
+}
+
+.messageboard__latestpost-content {
+  margin-top: 10px;
+  color: #d68686;
+}
+
+.fa-user-circle {
+  margin-right: 10px;
+}
+
+.messageboard__changepage {
+  max-width: 600px;
+  box-sizing: border-box;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 25px;
+}
+
+.messageboard__changepage-child {
+  border: solid 1px #d68686;
+  display: inline-flex;
+  border-radius: 2px;
+  padding: 2px 9px;
+  color: #d68686;
+  margin: 0px 2px 20px 5px;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.active {
+  background-color: #d68686;
+  color: white;
+  cursor: auto;
+}
+
+.messageboard__changepage-child:hover {
+  background-color: #d68686;
+  color: white;
+}
+
+@media screen and (min-width: 750px) {
+  .messageboard__newpost-input {
+    width: 600px;
+  }
+}
+
+@media screen and (max-width: 750px) and (min-width: 500px) {
+  .messageboard__newpost-input {
+    width: 389px;
+  }
+}
+
+@media screen and (max-width: 375px) {
+  .messageboard__title {
+    font-size: 40px;
+  }
+}

--- a/homeworks/week8/hw3/index.html
+++ b/homeworks/week8/hw3/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+
+<html>
+  <head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <title>Week8-hw3 Twitch-Live-League of Legends（Cindy）</title>
+    <link rel='stylesheet' href='./style.css'>
+     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
+  </head>
+  <body>
+      <div class='mask'></div><div class='live__title'>League of Legends（Live）</div>
+      <div class='livecontainer'></div>
+    <script src='./index.js'></script>
+  </body>
+</html>

--- a/homeworks/week8/hw3/index.js
+++ b/homeworks/week8/hw3/index.js
@@ -1,0 +1,50 @@
+const request = new XMLHttpRequest();
+const liveContainer = document.querySelector('.livecontainer');
+
+function viewersConversion(num) {
+  const numLength = num.toString().length;
+  let result = '';
+  if (numLength >= 4) {
+    for (let i = 0; i < numLength - 3; i += 1) {
+      result += num.toString()[i];
+    }
+    return `${result}k`;
+  }
+  return num;
+}
+
+request.onload = () => {
+  if (request.status >= 200 && request.status <= 400) {
+    const data = JSON.parse(request.responseText);
+    for (let i = 0; i < (data.streams).length; i += 1) {
+      const liveTitle = data.streams[i].channel.status;
+      const viewers = viewersConversion(data.streams[i].viewers);
+      const pic = data.streams[i].preview.medium;
+      const name = data.streams[i].channel.name;
+      const link = `https://www.twitch.tv/${name}`;
+      const avatar = data.streams[i].channel.logo;
+      const item = document.createElement('div');
+      item.classList.add('livecontent');
+      item.innerHTML = `<a href='${link}' target='_blank'>
+        <div class='livecontent__viewers'><i class="fas fa-user"></i>${viewers}</div>
+        <img class='livecontent__img' src='${pic}'>
+        <div class=livecontent__info>
+        <div><img class='livecontent__info-avatar' src='${avatar}'></div>
+          <div class='livecontent__info-text'>
+            <div class='livecontent__info-title'>${liveTitle}</div>
+            <div class='livecontent__info-name'>${name}</div></div>
+          </div></a>`;
+      liveContainer.appendChild(item);
+    }
+  } else {
+    console.log(request.responseText, request.status);
+  }
+};
+
+request.onerror = () => {
+  console.log(request.status);
+};
+
+request.open('GET', 'https://api.twitch.tv/kraken/streams/?game=League of Legends&limit=20', true);
+request.setRequestHeader('Client-ID', 'wdplbrt7uhnh4ep6lvk2ogkc1eyw6o');
+request.send();

--- a/homeworks/week8/hw3/style.css
+++ b/homeworks/week8/hw3/style.css
@@ -1,0 +1,132 @@
+* {
+  /*border: solid 1px red;*/
+  margin: 0px;
+}
+html {
+  background-image: url('https://live.staticflickr.com/905/41675744082_5b372bdd23_b.jpg');
+  background-attachment: fixed;
+  background-size: cover;
+}
+
+.mask {
+  background-color: rgba(0, 0, 0, 0.7);
+  background-attachment: fixed;
+  height: 310%;
+  width: 100%;
+  disaply: inline-block;
+  position: absolute;
+  z-index: -1;
+}
+
+.live__title {
+  font-size: 40px;
+  font-weight: bold;
+  text-align: center;
+  padding: 30px 0px 25px 0px;
+  color: white;
+}
+
+.livecontainer {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 1100px;
+  /*justify-content: center;*/
+  left: 50%;
+  /*top: 50%;*/
+  padding: 0px 0px 0px 10px;
+
+  transform: translateX(-50%);
+  /*margin-left: auto;*/
+  /*margin-left: 10%;*/
+  position: absolute;
+  /*left: 50%;*/
+}
+
+
+a {
+  text-decoration: none;
+  color: white;
+}
+
+.livecontent {
+  margin: 15px;
+  max-width: 320px;
+  /*border: solid 1px #666666;*/
+  position: relative;
+  background-color: rgba(70, 70, 70, 0.7);
+  color: white;
+  opacity: 0.9;
+  transition: 0.5s;
+}
+
+.livecontent:hover {
+  box-shadow: 0px 0px 15px rgba(70, 70, 70, 0.9);
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.livecontent__viewers {
+  position: absolute;
+  color: white;
+  top: 8px;
+  right: 9px;
+  /*border: solid 1px red;*/
+  background-color: #e26e6c;
+  border-radius: 3px;
+  padding: 4px 4px;
+  /*opacity: 0.8;*/
+  font-size: 12px;
+}
+
+.livecontent:hover .livecontent__viewers {
+  animation: live 1.5s infinite;
+}
+
+@keyframes live {
+  0% {
+    opacity: 0.8;
+  }
+  20% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+  75% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0.8;
+  }
+}
+
+.fa-user {
+  margin-right: 3px;
+}
+
+.livecontent__info {
+  padding: 10px;
+  display: flex;
+}
+
+.livecontent__info-text {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.livecontent__info-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.livecontent__info-avatar {
+  border-radius: 100%;
+  width: 40px;
+  margin-right: 10px;
+}
+
+@media screen and (min-width: 1440px) {
+  .livecontainer {
+    width: 1440px; // 當 1440px 時不知為何只能顯示兩列內容
+  }
+}

--- a/homeworks/week8/hw3/style.css
+++ b/homeworks/week8/hw3/style.css
@@ -1,7 +1,7 @@
 * {
-  /*border: solid 1px red;*/
   margin: 0px;
 }
+
 html {
   background-image: url('https://live.staticflickr.com/905/41675744082_5b372bdd23_b.jpg');
   background-attachment: fixed;
@@ -30,18 +30,11 @@ html {
   display: flex;
   flex-wrap: wrap;
   max-width: 1100px;
-  /*justify-content: center;*/
   left: 50%;
-  /*top: 50%;*/
   padding: 0px 0px 0px 10px;
-
   transform: translateX(-50%);
-  /*margin-left: auto;*/
-  /*margin-left: 10%;*/
   position: absolute;
-  /*left: 50%;*/
 }
-
 
 a {
   text-decoration: none;
@@ -51,7 +44,6 @@ a {
 .livecontent {
   margin: 15px;
   max-width: 320px;
-  /*border: solid 1px #666666;*/
   position: relative;
   background-color: rgba(70, 70, 70, 0.7);
   color: white;
@@ -70,11 +62,9 @@ a {
   color: white;
   top: 8px;
   right: 9px;
-  /*border: solid 1px red;*/
   background-color: #e26e6c;
   border-radius: 3px;
   padding: 4px 4px;
-  /*opacity: 0.8;*/
   font-size: 12px;
 }
 
@@ -127,6 +117,6 @@ a {
 
 @media screen and (min-width: 1440px) {
   .livecontainer {
-    width: 1440px; // 當 1440px 時不知為何只能顯示兩列內容
+    width: 1440px; // 當螢幕為 1440px 時不知為何只能顯示兩列實況資訊內容，故加上此來輔助顯示三列
   }
 }

--- a/homeworks/week8/hw4.md
+++ b/homeworks/week8/hw4.md
@@ -1,14 +1,36 @@
 ## 什麼是 Ajax？
-
+非同步與伺服器交換資料都可稱為 AJAX。
 
 ## 用 Ajax 與我們用表單送出資料的差別在哪？
-
+AJAX 是用於非同步的載入技術，且可以達到不換頁的效果，像是在 Google 首頁中於搜尋欄位輸入關鍵字時，會出現下拉式的一些選項可以提供作選擇，或是 Gmail 中寫信完成後沒有換頁的狀況下送出，就是使用 AJAX，如果用表單送出資料就會需要將 request 送到另一個頁面，server 再回傳 response 回來。
 
 ## JSONP 是什麼？
-
+全名為 JSON with Padding，僅能在網址上加上參數（GET 的方式），利用 ```script``` 標籤引入該 API 網址，然後利用該 API 已經寫好的 function 來使用並匯入資料，可以讓該 request 不受同源政策的影響（像是如下範例），是一個很奇妙的方式，但現在比較少人在用。
+```HTML
+// HTML
+<script>
+  function setData(users) {
+    console.log(users)
+  }
+</script>
+<script src='http://test.com/user.js'></script>
+```
+```javascript
+// JavaScript
+setData([
+  {
+    id: 1,
+    name: ‘hello’
+  }, {
+    id: 2,
+  }
+])
+```
 
 ## 要如何存取跨網域的 API？
-
+必須符合瀏覽器的同源政策，或是 response 的 server 有設定 CORS，CORS 為跨來源資源共用，CORS 就是當有在 server 的 headers 設定 ```access-control-origin``` 並寫下同意哪些來源可以使用，符合的話瀏覽器才會放行 request 給 server，或有些會直接在 ```access-control-origin``` 設定 ```*``` 代表任何來源都可以發 request。
 
 ## 為什麼我們在第四週時沒碰到跨網域的問題，這週卻碰到了？
+> 其實剛開始在看到這一題時，直覺是第四週不是也有跨網域嗎？QQ（因為從自己電腦本機發送 request 到串接作業中 twitch api 時應該也算是跨網域（？）
 
+後來再去稍微複習一下課程想想，覺得這一題可能是要問同源政策，所以這週碰到的原因應該是因為這週學習了透過瀏覽器發送 request，而第四週是使用 node.js，在使用瀏覽器發送 request 時，瀏覽器會有同源政策的規範，也會幫我們在 request 上加上一些資訊一起傳送給 server，根據同源政策，也會讓瀏覽器去審核我們是否與 server 是同個 domain，且 http 或 https 也要相同， port 也是；而直接用 node.js 就不會有瀏覽器同源政策的影響，因為沒透過瀏覽器，是直接用 JavaScript 發送 request 給 sever。


### PR DESCRIPTION
### hw1 進階挑戰題
各獎項機率，分別跑了三次，前兩次跑一百次，最後一次跑一千次（都是沒扣除「系統不穩定」出現的次數），然後將三次各平均再次加總平均，把最後機率四捨五入都用成整數（除了銘謝惠顧原先 44.20% 直接升 45% 讓機率加總 100%，雖然那少的機率可能也可以推給「系統不穩定」）
1. 頭獎：5%
2. 二獎：20%
3. 三獎：30%
4. 銘謝惠顧：45%

### 心得
 - 最近作業做完都有一種畫面上也沒什麼東西，卻做了好久才完成，關於 hw2、hw3 ESlint 都有跳解構的 error 出來，但都忽略過去了，原因是覺得 api 提供的資料較多，所以想不太到可以如何用解構的方式，而 hw2 更是資料數（留言數）不確定，所以先忽略了解構的 error 訊息
 - hw3 當 hover 到實況區塊內容時，觀看人數的閃爍可能不太自然，想不太起來其他地方是如何呈現，也一時找不太到適合的來做模仿，而一樣 hover 時內容放大及內容是模仿[學姊](https://cwenwen.github.io/APIsPractice/Twitch_API/)的XD，原本看到覺得還蠻好看的但沒想到怎麼做，後來做完的時候就想到可以利用 scale 放大及 z-index 搭配
 - hw3 的 css 有加個最小螢幕為 1440px 時整個實況區塊的寬度為 1440px，因為找不太到原因，關於為何中間的內容會自己變成兩列內容，但寬度是夠的，所以最後只好用了螢幕大小來限制了。
- (6/8 新增）hw2 留言板，第一頁（不含第一頁）之後會每頁顯示 21 個（原預期顯示 20 個），故某些總留言數時會造成最後一頁空白內容頁（問題點為計算每頁顯示的 ID 公式錯誤，之後會再更新上去）

```
謝謝 Huli 改作業
```